### PR TITLE
Support issuing claims with yaml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.9.30"
 thiserror = "1.0.51"
 rand = "0.8.5"
 base64 = "0.21.5"

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,4 +43,8 @@ pub enum Error {
     RsaPkcs8Error(#[from] rsa::pkcs8::Error),
     #[error("UTF8 conversion error")]
     Utf8Error(#[from] std::str::Utf8Error),
+    #[error("YAML parsing error")]
+    YamlError(#[from] serde_yaml::Error),
+    #[error("YAML invalid sd tag: {0}")]
+    YamlInvalidSDTag(String),
 }

--- a/src/issuer.rs
+++ b/src/issuer.rs
@@ -4,6 +4,7 @@ use crate::Header;
 use crate::Jwk;
 use crate::{encode, KeyForEncoding};
 use chrono::{Duration, Utc};
+use core::slice::Iter;
 use serde::Serialize;
 use serde_json::Value;
 use std::ops::Deref;
@@ -258,6 +259,53 @@ impl Issuer {
     /// ```
     pub fn require_key_binding(&mut self, key_binding_pubkey: Jwk) -> &mut Self {
         self.key_binding_pubkey = Some(key_binding_pubkey);
+        self
+    }
+
+    /// Marks claims as disclosable.
+    /// This method is useful when you want to mark multiple claims as disclosable.
+    /// It accepts an iterator of claim paths.
+    ///
+    /// # Arguments
+    /// * `path_iter` - An iterator of claim paths.
+    ///
+    /// # Returns
+    /// A mutable reference to the issuer for method chaining.
+    ///
+    /// # Examples
+    /// ```
+    /// use sdjwt::Issuer;
+    ///
+    /// let claims = serde_json::json!({
+    ///   "sub": "user_42",
+    ///  "given_name": "John",
+    /// "family_name": "Doe",
+    /// "email": "johndoe@example",
+    /// "address": {
+    ///   "street_address": "123 Main St",
+    ///  "locality": "Anytown",
+    /// "region": "Anystate",
+    /// "country": "US"
+    /// },
+    /// "nationalities": [
+    ///  "US",
+    /// "DE"
+    /// ]
+    /// });
+    ///
+    /// let mut issuer = Issuer::new(claims).unwrap();
+    /// issuer.iter_disclosable(vec![
+    ///     "/given_name".to_string(),
+    ///     "/family_name".to_string(),
+    ///     "/address/street_address".to_string(),
+    ///     "/address/locality".to_string(),
+    ///     "/nationalities/0".to_string(),
+    ///     "/nationalities/1".to_string()].iter());
+    /// ```
+    pub fn iter_disclosable(&mut self, path_iter: Iter<String>) -> &mut Self {
+        path_iter.for_each(|path| {
+            self.disclosable(path);
+        });
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod header;
 pub mod holder;
 pub mod issuer;
 pub mod jwk;
+mod parser;
 #[cfg(feature = "noring")]
 pub(crate) mod registries;
 mod utils;
@@ -27,5 +28,6 @@ pub use header::*;
 pub use holder::*;
 pub use issuer::*;
 pub use jwk::*;
+pub use parser::parse_yaml;
 pub use validation::*;
 pub use verifier::*;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,252 @@
+use crate::Error;
+use serde::{Deserialize, Deserializer};
+use serde_json::Value as JsonValue;
+use serde_yaml::Value as YamlValue;
+use std::collections::VecDeque;
+
+#[derive(Debug)]
+struct CustomYamlValue {
+    value: YamlValue,
+    tagged_paths: Vec<String>,
+}
+
+impl<'de> Deserialize<'de> for CustomYamlValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserialize_custom_yaml(deserializer)
+    }
+}
+
+fn deserialize_custom_yaml<'de, D>(deserializer: D) -> Result<CustomYamlValue, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut value = YamlValue::deserialize(deserializer)?;
+    let mut path = VecDeque::new();
+    let mut tagged_paths = Vec::new();
+    collect_tagged_keys(&mut value, &mut path, &mut tagged_paths).map_err(|e| {
+        serde::de::Error::custom(format!("Error parsing YAML at path {:?}: {:?}", path, e))
+    })?;
+    Ok(CustomYamlValue {
+        value,
+        tagged_paths,
+    })
+}
+
+fn collect_tagged_keys(
+    node: &mut YamlValue,
+    path: &mut VecDeque<String>,
+    paths: &mut Vec<String>,
+) -> Result<(), Error> {
+    match node {
+        YamlValue::Mapping(map) => {
+            for (key, value) in map {
+                if let YamlValue::Tagged(tag) = &key {
+                    let key_str = tag.as_ref().tag.to_string();
+                    if key_str == "!sd" {
+                        let new_val = tag
+                            .as_ref()
+                            .value
+                            .as_str()
+                            .ok_or(Error::YamlInvalidSDTag(key_str))?;
+                        let full_path = build_full_path(path, new_val);
+                        paths.push(full_path);
+                    }
+                } else if let YamlValue::String(key) = &key {
+                    path.push_back(key.to_string());
+                    collect_tagged_keys(value, path, paths)?;
+                    path.pop_back();
+                }
+            }
+        }
+        YamlValue::Sequence(seq) => {
+            for (index, value) in seq.iter_mut().enumerate() {
+                path.push_back(index.to_string());
+                collect_tagged_keys(value, path, paths)?;
+                // Ugly hack to remove tag from sequence
+                if let YamlValue::Tagged(tag) = &value {
+                    let key_str = tag.as_ref().tag.to_string();
+                    if key_str == "!sd" {
+                        let new_val = tag
+                            .as_ref()
+                            .value
+                            .as_str()
+                            .ok_or(Error::YamlInvalidSDTag(key_str))?;
+                        *value = YamlValue::String(new_val.to_string());
+                    }
+                }
+                path.pop_back();
+            }
+        }
+        YamlValue::Tagged(tag) => {
+            let key_str = tag.as_ref().tag.to_string();
+            if key_str == "!sd" {
+                let mut full_path = String::new();
+                for (index, path_fragment) in path.iter().enumerate() {
+                    if index == 0 {
+                        full_path = format!("/{}", path_fragment);
+                    } else {
+                        full_path = format!("{}/{}", full_path, path_fragment)
+                    }
+                }
+                paths.push(full_path);
+            }
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+fn build_full_path(path: &VecDeque<String>, additional_segment: &str) -> String {
+    let full_path = path
+        .iter()
+        .fold(String::new(), |acc, frag| format!("{}/{}", acc, frag));
+    format!("{}/{}", full_path, additional_segment)
+}
+
+/// Parses claims as a YAML string, converts it to JSON, and collects paths of elements tagged with `!sd`.
+///
+/// # Arguments
+/// * `yaml_str` - A string slice that holds the YAML data.
+///
+/// # Returns
+/// A `Result` containing a tuple of JSON value and a vector of tagged paths, or an error.
+pub fn parse_yaml(yaml_str: &str) -> Result<(JsonValue, Vec<String>), Error> {
+    let yaml_value: CustomYamlValue = serde_yaml::from_str(yaml_str)?;
+    let json_str = serde_yaml::to_string(&yaml_value.value)?;
+    let json: JsonValue = serde_yaml::from_str(&json_str)?;
+    let tagged_paths = yaml_value.tagged_paths;
+    Ok((json, tagged_paths))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_yaml1() {
+        let yaml_str = r#"
+            sub: user_42
+            !sd given_name: John
+            !sd family_name: Doe
+            email: "johndoe@example.com"
+            phone_number: "+1-202-555-0101"
+            phone_number_verified: true
+            address:
+                !sd street_address: "123 Main St"
+                !sd locality: Anytown
+                region: Anystate
+                country: US
+            birthdate: "1940-01-01"
+            updated_at: 1570000000
+            !sd nationalities:
+                - US
+                - DE
+            "#;
+
+        let (json, tagged_paths) = parse_yaml(yaml_str).unwrap();
+        println!("{:?}", json);
+        println!("{:?}", tagged_paths);
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "sub": "user_42",
+                "given_name": "John",
+                "family_name": "Doe",
+                "email": "johndoe@example.com",
+                "phone_number": "+1-202-555-0101",
+                "phone_number_verified": true,
+                "address": {
+                    "street_address": "123 Main St",
+                    "locality": "Anytown",
+                    "region": "Anystate",
+                    "country": "US"
+                },
+                "birthdate": "1940-01-01",
+                "updated_at": 1570000000,
+                "nationalities": [
+                    "US",
+                    "DE"
+                ]
+            })
+        );
+
+        assert_eq!(
+            tagged_paths,
+            vec![
+                "/given_name",
+                "/family_name",
+                "/address/street_address",
+                "/address/locality",
+                "/nationalities",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_yaml2() {
+        let yaml_str = r#"
+            sub: user_42
+            !sd given_name: John
+            !sd family_name: Doe
+            email: "johndoe@example.com"
+            phone_number: "+1-202-555-0101"
+            phone_number_verified: true
+            !sd address:
+                street_address: "123 Main St"
+                locality: Anytown
+                region: Anystate
+                country: US
+            birthdate: "1940-01-01"
+            updated_at: 1570000000
+            nationalities:
+                - !sd US
+                - !sd DE
+                - PL
+            "#;
+
+        let (json, tagged_paths) = parse_yaml(yaml_str).unwrap();
+        println!("{:?}", json);
+        println!("{:?}", tagged_paths);
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "sub": "user_42",
+                "given_name": "John",
+                "family_name": "Doe",
+                "email": "johndoe@example.com",
+                "phone_number": "+1-202-555-0101",
+                "phone_number_verified": true,
+                "address": {
+                    "street_address": "123 Main St",
+                    "locality": "Anytown",
+                    "region": "Anystate",
+                    "country": "US"
+                },
+                "birthdate": "1940-01-01",
+                "updated_at": 1570000000,
+                "nationalities": [
+                    "US",
+                    "DE",
+                    "PL"
+                ]
+            })
+        );
+
+        assert_eq!(
+            tagged_paths,
+            vec![
+                "/given_name",
+                "/family_name",
+                "/address",
+                "/nationalities/0",
+                "/nationalities/1",
+            ]
+        );
+    }
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,105 @@
+use base64::Engine;
+use rand::rngs::OsRng;
+use rsa::pkcs1::EncodeRsaPublicKey;
+use rsa::pkcs8::EncodePrivateKey;
+use rsa::PublicKeyParts;
+use rsa::{RsaPrivateKey, RsaPublicKey};
+use serde_json::value::{Map, Value};
+use std::collections::HashSet;
+
+pub fn keys() -> (RsaPrivateKey, RsaPublicKey) {
+    let mut rng = OsRng;
+    let bits = 2048;
+    let private_key = RsaPrivateKey::new(&mut rng, bits).unwrap();
+    let public_key = RsaPublicKey::from(&private_key);
+
+    (private_key, public_key)
+}
+
+pub fn convert_to_pem(private_key: RsaPrivateKey, public_key: RsaPublicKey) -> (String, String) {
+    (
+        private_key
+            .to_pkcs8_pem(rsa::pkcs8::LineEnding::CR)
+            .unwrap()
+            .to_string(),
+        public_key.to_pkcs1_pem(rsa::pkcs1::LineEnding::CR).unwrap(),
+    )
+}
+
+pub fn publickey_to_jwk(public_key: &RsaPublicKey) -> serde_json::Value {
+    let n = public_key.n().to_bytes_be();
+    let e = public_key.e().to_bytes_be();
+
+    serde_json::json!({
+        "kty": "RSA",
+        "n": base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(n),
+        "e": base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(e),
+        "alg": "RS256",
+        "use": "sig",
+    })
+}
+
+pub fn compare_json_values(json1: &Value, json2: &Value) -> bool {
+    match (json1, json2) {
+        (Value::Object(map1), Value::Object(map2)) => compare_json_maps(map1, map2),
+        (Value::Array(arr1), Value::Array(arr2)) => compare_json_arrays(arr1, arr2),
+        _ => json1 == json2,
+    }
+}
+
+pub fn compare_json_maps(map1: &Map<String, Value>, map2: &Map<String, Value>) -> bool {
+    if map1.len() != map2.len() {
+        return false;
+    }
+
+    map1.iter().all(|(key, val1)| {
+        map2.get(key)
+            .map_or(false, |val2| compare_json_values(val1, val2))
+    })
+}
+
+pub fn compare_json_arrays(arr1: &[Value], arr2: &[Value]) -> bool {
+    if arr1.len() != arr2.len() {
+        return false;
+    }
+
+    let mut matched_indices = HashSet::new();
+
+    for val1 in arr1 {
+        let mut is_matched = false;
+
+        for (index, val2) in arr2.iter().enumerate() {
+            if !matched_indices.contains(&index) && compare_json_values(val1, val2) {
+                is_matched = true;
+                matched_indices.insert(index);
+                break;
+            }
+        }
+
+        if !is_matched {
+            return false;
+        }
+    }
+
+    true
+}
+
+pub fn separate_jwt_and_disclosures(input: &str) -> (String, String) {
+    let parts: Vec<&str> = input.splitn(2, '~').collect();
+    if parts.len() == 2 {
+        (parts[0].to_string(), parts[1].to_string())
+    } else {
+        (input.to_string(), "".to_string())
+    }
+}
+
+pub fn disclosures2vec(disclosures: &str) -> Vec<String> {
+    let parts: Vec<&str> = disclosures.split('~').collect();
+    if parts.is_empty() {
+        return Vec::new();
+    }
+    parts[..parts.len() - 1]
+        .iter()
+        .map(|&s| s.to_string())
+        .collect()
+}

--- a/tests/encoding_decoding_test.rs
+++ b/tests/encoding_decoding_test.rs
@@ -1,0 +1,322 @@
+use chrono::{Duration, Utc};
+use sdjwt::{
+    decode, parse_yaml, sd_jwt_parts, Algorithm, Disclosure, Error, HashAlgorithm, Holder, Issuer,
+    Jwk, KeyForDecoding, KeyForEncoding, Validation, Verifier,
+};
+use std::collections::HashSet;
+
+use common::{
+    compare_json_values, convert_to_pem, disclosures2vec, keys, publickey_to_jwk,
+    separate_jwt_and_disclosures,
+};
+use serde_json::value::Value;
+
+mod common;
+
+const TEST_CLAIMS: &str = r#"{
+        "sub": "user_42",
+        "given_name": "John",
+        "family_name": "Doe",
+        "email": "johndoe@example.com",
+        "phone_number": "+1-202-555-0101",
+        "phone_number_verified": true,
+        "address": {
+            "street_address": "123 Main St",
+            "locality": "Anytown",
+            "region": "Anystate",
+            "country": "US"
+        },
+        "birthdate": "1940-01-01",
+        "updated_at": 1570000000,
+        "nationalities": [
+            "US",
+            "DE"
+        ]
+    }"#;
+
+const TEST_CLAIMS_YAML: &str = r#"
+    sub: user_42
+    !sd given_name: John
+    !sd family_name: Doe
+    email: johndoe@example.com
+    phone_number: +1-202-555-0101
+    phone_number_verified: true
+    address:
+        !sd street_address: 123 Main St
+        !sd locality: Anytown
+        region: Anystate
+        country: US
+    birthdate: 1940-01-01
+    updated_at: 1570000000
+    nationalities:
+        - !sd US
+        - !sd DE
+    "#;
+
+const TEST_VERIFIER_EXPECTED_CLAIMS: &str = r#"{
+        "sub": "user_42",
+        "given_name": "John",
+        "email": "johndoe@example.com",
+        "phone_number": "+1-202-555-0101",
+        "phone_number_verified": true,
+        "address": {
+            "locality": "Anytown",
+            "region": "Anystate",
+            "country": "US"
+        },
+        "birthdate": "1940-01-01",
+        "updated_at": 1570000000,
+        "nationalities": [
+            "DE"
+        ]
+    }"#;
+
+#[test]
+fn test_basic_encoding_decoding() -> Result<(), Error> {
+    let (priv_key, pub_key) = keys();
+    let (issuer_private_key, issuer_public_key) = convert_to_pem(priv_key, pub_key);
+    let mut claims: Value = serde_json::from_str(TEST_CLAIMS).unwrap();
+    let now = Utc::now();
+    let expiration = now + Duration::minutes(5);
+    let exp = expiration.timestamp();
+    claims["exp"] = serde_json::json!(exp);
+    let mut issuer = Issuer::new(claims)?;
+    let encoded = issuer
+        .disclosable("/given_name")
+        .disclosable("/family_name")
+        .disclosable("/address/street_address")
+        .disclosable("/address/locality")
+        .disclosable("/nationalities/0")
+        .disclosable("/nationalities/1")
+        .encode(&crate::KeyForEncoding::from_rsa_pem(
+            issuer_private_key.as_bytes(),
+        )?)?;
+    println!("encoded: {:?}", encoded);
+    let dot_segments = encoded.split('.').count();
+    let disclosure_segments = encoded.split('~').count() - 2;
+
+    assert_eq!(dot_segments, 3);
+    assert_eq!(disclosure_segments, 6);
+
+    // get issuer JWT by splitting left part of the string at the first ~
+    let issuer_jwt = encoded.split('~').next().unwrap();
+    let (header, claims) = decode(
+        issuer_jwt,
+        &KeyForDecoding::from_rsa_pem(issuer_public_key.as_bytes()).unwrap(),
+        &Validation::default(),
+    )?;
+    println!("header: {:?}", header);
+    println!("claims: {:?}", claims);
+
+    assert_eq!(header["alg"], "RS256");
+    assert_eq!(header["typ"], "sd-jwt");
+    assert_eq!(claims["sub"], "user_42");
+    assert!(claims["_sd"].is_array());
+    assert_eq!(claims["_sd"].as_array().unwrap().len(), 2);
+    assert!(claims["address"]["_sd"].is_array());
+    assert_eq!(claims["address"]["_sd"].as_array().unwrap().len(), 2);
+    assert_eq!(claims["_sd_alg"], "sha-256");
+    assert!(claims["nationalities"].is_array());
+    assert_eq!(claims["nationalities"].as_array().unwrap().len(), 2);
+    assert!(claims["nationalities"][0].is_object());
+    assert!(claims["nationalities"][1].is_object());
+    Ok(())
+}
+
+#[test]
+fn test_presentation_verification_with_kb() -> Result<(), Error> {
+    // create issuer sd-jwt
+    let (priv_key, pub_key) = keys();
+    let (issuer_private_key, issuer_public_key) = convert_to_pem(priv_key, pub_key);
+    let (holder_private_key, holder_public_key) = keys();
+    let holder_jwk = publickey_to_jwk(&holder_public_key);
+    let (holder_private_key_pem, _) = convert_to_pem(holder_private_key, holder_public_key);
+    let claims: Value = serde_json::from_str(TEST_CLAIMS).unwrap();
+    let mut issuer = Issuer::new(claims)?;
+    let issuer_sd_jwt = issuer
+        .expires_in_seconds(60)
+        .disclosable("/given_name")
+        .disclosable("/family_name")
+        .disclosable("/address/street_address")
+        .disclosable("/address/locality")
+        .disclosable("/nationalities/0")
+        .disclosable("/nationalities/1")
+        .require_key_binding(Jwk::from_value(holder_jwk)?)
+        .encode(&KeyForEncoding::from_rsa_pem(
+            issuer_private_key.as_bytes(),
+        )?)?;
+    println!("issuer_sd_jwt: {:?}", issuer_sd_jwt);
+
+    // verify issuer sd-jwt by holder
+    let validation = Validation::default();
+    let decoding_key = KeyForDecoding::from_rsa_pem(issuer_public_key.as_bytes())?;
+    let (header, decoded_claims, disclosure_paths) =
+        Holder::verify(&issuer_sd_jwt, &decoding_key, &validation)?;
+    println!("header: {:?}", header);
+    println!("claims: {:?}", decoded_claims);
+    println!("disclosure_paths: {:?}", disclosure_paths);
+
+    // holder creates presentation
+    let presentation = Holder::presentation(&issuer_sd_jwt)?
+        .redact("/family_name")?
+        .redact("/address/street_address")?
+        .redact("/nationalities/0")?
+        .key_binding(
+            "https://someone.example.com",
+            &KeyForEncoding::from_rsa_pem(holder_private_key_pem.as_bytes())?,
+            Algorithm::RS256,
+        )?
+        .build()?;
+    println!("presentation: {:?}", presentation);
+    let (issuer_jwt, disclosures, kb_jwt) = sd_jwt_parts(&presentation);
+
+    let issuer_dot_segments = issuer_jwt.split('.').count();
+    let kb_jwt_dot_segments = kb_jwt.as_ref().unwrap().split('.').count();
+
+    assert_eq!(issuer_dot_segments, 3);
+    assert_eq!(kb_jwt_dot_segments, 3);
+    assert_eq!(disclosures.len(), 3);
+
+    let (_, disclosure_parts) = separate_jwt_and_disclosures(&presentation);
+    let disclosures = disclosures2vec(&disclosure_parts);
+    assert_eq!(disclosures.len(), 3);
+    let d0 = Disclosure::from_base64(&disclosures[0], HashAlgorithm::SHA256)?;
+    let d1 = Disclosure::from_base64(&disclosures[1], HashAlgorithm::SHA256)?;
+    let d2 = Disclosure::from_base64(&disclosures[2], HashAlgorithm::SHA256)?;
+    assert_eq!(d0.key(), &Some("given_name".to_string()));
+    assert_eq!(d0.value(), &serde_json::json!("John"));
+    assert_eq!(d1.key(), &Some("locality".to_string()));
+    assert_eq!(d1.value(), &serde_json::json!("Anytown"));
+    assert_eq!(d2.key(), &None);
+    assert_eq!(d2.value(), &serde_json::json!("DE"));
+
+    // Verifier verifies presentation
+    let validation = Validation::default();
+    let mut kb_validation = Validation::default().no_exp();
+    let mut audience = HashSet::new();
+    audience.insert("https://someone.example.com".to_string());
+    kb_validation.aud = Some(audience);
+    let decoding_key = KeyForDecoding::from_rsa_pem(issuer_public_key.as_bytes())?;
+    let (ver_header, ver_claims) = Verifier::verify(
+        &presentation,
+        &decoding_key,
+        &validation,
+        &Some(&kb_validation),
+    )?;
+
+    println!("ver_header: {:?}", ver_header);
+    println!("ver_claims: {:?}", ver_claims);
+
+    let mut ver_claims_without_exp = ver_claims.clone();
+    ver_claims_without_exp
+        .as_object_mut()
+        .unwrap()
+        .remove("exp");
+    ver_claims_without_exp
+        .as_object_mut()
+        .unwrap()
+        .remove("cnf");
+    assert!(compare_json_values(
+        &serde_json::from_str(TEST_VERIFIER_EXPECTED_CLAIMS)?,
+        &ver_claims_without_exp
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn test_issue_claims_with_yaml() -> Result<(), Error> {
+    // create issuer sd-jwt
+    let (priv_key, pub_key) = keys();
+    let (issuer_private_key, issuer_public_key) = convert_to_pem(priv_key, pub_key);
+    let (holder_private_key, holder_public_key) = keys();
+    let holder_jwk = publickey_to_jwk(&holder_public_key);
+    let (holder_private_key_pem, _) = convert_to_pem(holder_private_key, holder_public_key);
+
+    let (claims, tagged_paths) = parse_yaml(TEST_CLAIMS_YAML)?;
+    let mut issuer = Issuer::new(claims)?;
+    let issuer_sd_jwt = issuer
+        .expires_in_seconds(60)
+        .require_key_binding(Jwk::from_value(holder_jwk)?)
+        .iter_disclosable(tagged_paths.iter())
+        .encode(&KeyForEncoding::from_rsa_pem(
+            issuer_private_key.as_bytes(),
+        )?)?;
+    println!("issuer_sd_jwt: {:?}", issuer_sd_jwt);
+
+    // verify issuer sd-jwt by holder
+    let validation = Validation::default();
+    let decoding_key = KeyForDecoding::from_rsa_pem(issuer_public_key.as_bytes())?;
+    let (header, decoded_claims, disclosure_paths) =
+        Holder::verify(&issuer_sd_jwt, &decoding_key, &validation)?;
+    println!("header: {:?}", header);
+    println!("claims: {:?}", decoded_claims);
+    println!("disclosure_paths: {:?}", disclosure_paths);
+
+    // holder creates presentation
+    let presentation = Holder::presentation(&issuer_sd_jwt)?
+        .redact("/family_name")?
+        .redact("/address/street_address")?
+        .redact("/nationalities/0")?
+        .key_binding(
+            "https://someone.example.com",
+            &KeyForEncoding::from_rsa_pem(holder_private_key_pem.as_bytes())?,
+            Algorithm::RS256,
+        )?
+        .build()?;
+    println!("presentation: {:?}", presentation);
+    let (issuer_jwt, disclosures, kb_jwt) = sd_jwt_parts(&presentation);
+
+    let issuer_dot_segments = issuer_jwt.split('.').count();
+    let kb_jwt_dot_segments = kb_jwt.as_ref().unwrap().split('.').count();
+
+    assert_eq!(issuer_dot_segments, 3);
+    assert_eq!(kb_jwt_dot_segments, 3);
+    assert_eq!(disclosures.len(), 3);
+
+    let (_, disclosure_parts) = separate_jwt_and_disclosures(&presentation);
+    let disclosures = disclosures2vec(&disclosure_parts);
+    assert_eq!(disclosures.len(), 3);
+    let d0 = Disclosure::from_base64(&disclosures[0], HashAlgorithm::SHA256)?;
+    let d1 = Disclosure::from_base64(&disclosures[1], HashAlgorithm::SHA256)?;
+    let d2 = Disclosure::from_base64(&disclosures[2], HashAlgorithm::SHA256)?;
+    assert_eq!(d0.key(), &Some("given_name".to_string()));
+    assert_eq!(d0.value(), &serde_json::json!("John"));
+    assert_eq!(d1.key(), &Some("locality".to_string()));
+    assert_eq!(d1.value(), &serde_json::json!("Anytown"));
+    assert_eq!(d2.key(), &None);
+    assert_eq!(d2.value(), &serde_json::json!("DE"));
+
+    // Verifier verifies presentation
+    let validation = Validation::default();
+    let mut kb_validation = Validation::default().no_exp();
+    let mut audience = HashSet::new();
+    audience.insert("https://someone.example.com".to_string());
+    kb_validation.aud = Some(audience);
+    let decoding_key = KeyForDecoding::from_rsa_pem(issuer_public_key.as_bytes())?;
+    let (ver_header, ver_claims) = Verifier::verify(
+        &presentation,
+        &decoding_key,
+        &validation,
+        &Some(&kb_validation),
+    )?;
+
+    println!("ver_header: {:?}", ver_header);
+    println!("ver_claims: {:?}", ver_claims);
+
+    let mut ver_claims_without_exp = ver_claims.clone();
+    ver_claims_without_exp
+        .as_object_mut()
+        .unwrap()
+        .remove("exp");
+    ver_claims_without_exp
+        .as_object_mut()
+        .unwrap()
+        .remove("cnf");
+    assert!(compare_json_values(
+        &serde_json::from_str(TEST_VERIFIER_EXPECTED_CLAIMS)?,
+        &ver_claims_without_exp
+    ));
+
+    Ok(())
+}


### PR DESCRIPTION
New API to support declaring claims and selecting disclosures with YAML.

Example:

```
const CLAIMS_YAML: &str = r#"
    sub: user_42
    !sd given_name: John
    !sd family_name: Doe
    email: johndoe@example.com
    phone_number: +1-202-555-0101
    phone_number_verified: true
    address:
        !sd street_address: 123 Main St
        !sd locality: Anytown
        region: Anystate
        country: US
    birthdate: 1940-01-01
    updated_at: 1570000000
    nationalities:
        - !sd US
        - !sd DE
    "#;

let (claims, tagged_paths) = parse_yaml(CLAIMS_YAML)?;
    let mut issuer = Issuer::new(claims)?;
    let issuer_sd_jwt = issuer
        .expires_in_seconds(60)
        .require_key_binding(Jwk::from_value(holder_jwk)?)
        .iter_disclosable(tagged_paths.iter())
        .encode(&KeyForEncoding::from_rsa_pem(
            issuer_private_key.as_bytes(),
        )?)?;
```

Any claims marked with `!sd` tag are selectively disclosable. 